### PR TITLE
Add callbacks to the next and prev buttons 

### DIFF
--- a/include/PageMenu.h
+++ b/include/PageMenu.h
@@ -33,8 +33,8 @@ public:
         float m_lastChildrenCount;
         float m_buttonWidth;
 
-        std::function<void(CCObject*)> m_nextCallback;
-        std::function<void(CCObject*)> m_prevCallback;
+        std::function<void(CCObject*)> m_nextCallback = [](CCObject* obj) {};
+        std::function<void(CCObject*)> m_prevCallback = [](CCObject* obj) {};
     };
     void setPaged(int count, PageOrientation orientation, float max, float padding = 4);
     void setPage(int pageNum);

--- a/include/PageMenu.h
+++ b/include/PageMenu.h
@@ -32,6 +32,9 @@ public:
         float m_buttonScale = 0.75;
         float m_lastChildrenCount;
         float m_buttonWidth;
+
+        std::function<void(CCObject*)> nextCallback;
+        std::function<void(CCObject*)> prevCallback;
     };
     void setPaged(int count, PageOrientation orientation, float max, float padding = 4);
     void setPage(int pageNum);
@@ -42,6 +45,9 @@ public:
     void enablePages(bool enable);
     void setButtonScale(float scale);
     void setFixed(float max);
+
+    void setNextCallback(std::function<void(CCObject*)> callback);
+    void setPrevCallback(std::function<void(CCObject*)> callback);
 
 private:
     void nextPage(cocos2d::CCObject* obj);

--- a/include/PageMenu.h
+++ b/include/PageMenu.h
@@ -12,8 +12,8 @@
     #else
         #define PAGES_API_DLL __declspec(dllimport)
     #endif
-    #else
-        #define PAGES_API_DLL __attribute__((visibility("default")))
+#else
+    #define PAGES_API_DLL __attribute__((visibility("default")))
 #endif
 
 struct PAGES_API_DLL PageMenu : public geode::Modify<PageMenu, cocos2d::CCMenu> {

--- a/include/PageMenu.h
+++ b/include/PageMenu.h
@@ -33,8 +33,8 @@ public:
         float m_lastChildrenCount;
         float m_buttonWidth;
 
-        std::function<void(CCObject*)> nextCallback;
-        std::function<void(CCObject*)> prevCallback;
+        std::function<void(CCObject*)> m_nextCallback;
+        std::function<void(CCObject*)> m_prevCallback;
     };
     void setPaged(int count, PageOrientation orientation, float max, float padding = 4);
     void setPage(int pageNum);

--- a/src/PageMenu.cpp
+++ b/src/PageMenu.cpp
@@ -239,6 +239,8 @@ void PageMenu::nextPage(CCObject* obj) {
     fields->m_currentPage++;
     if (fields->m_currentPage >= fields->m_pageCount) fields->m_currentPage = 0;
     setPage(fields->m_currentPage);
+
+    m_fields->m_nextCallback(obj);
 }
 
 void PageMenu::prevPage(CCObject* obj) {
@@ -246,4 +248,9 @@ void PageMenu::prevPage(CCObject* obj) {
     fields->m_currentPage--;
     if (fields->m_currentPage < 0) fields->m_currentPage = fields->m_pageCount - 1;
     setPage(fields->m_currentPage);
+
+    m_fields->m_prevCallback(obj);
 }
+
+void setNextCallback(std::function<void(CCObject*)> callback) {m_fields->m_nextCallback = callback;}
+void setPrevCallback(std::function<void(CCObject*)> callback) {m_fields->m_prevCallback = callback;}

--- a/src/PageMenu.cpp
+++ b/src/PageMenu.cpp
@@ -252,5 +252,5 @@ void PageMenu::prevPage(CCObject* obj) {
     m_fields->m_prevCallback(obj);
 }
 
-void setNextCallback(std::function<void(CCObject*)> callback) {m_fields->m_nextCallback = callback;}
-void setPrevCallback(std::function<void(CCObject*)> callback) {m_fields->m_prevCallback = callback;}
+void PageMenu::setNextCallback(std::function<void(CCObject*)> callback) {m_fields->m_nextCallback = callback;}
+void PageMenu::setPrevCallback(std::function<void(CCObject*)> callback) {m_fields->m_prevCallback = callback;}


### PR DESCRIPTION
allows devs who are using the API to add their own extra code to be executed when clicking on the next and prev in the paged menu 